### PR TITLE
Fixed 'kind' in meta.json, and corrected OneFS network mapping

### DIFF
--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -251,10 +251,11 @@ class TestFunctions(unittest.TestCase):
         """``templates`` create_machine_meta constructs the expected dictionary"""
         portmaps = [{'name': 'vm01', 'target_addr': '1.2.3.4', 'target_ports': [22]}, {'name' : 'vm02', 'target_addr': '1.2.3.5', 'target_ports': [443]}]
         template = 'myCoolTemplate'
+        vm_kind_map = {'vm01': 'OneFS', 'vm02': 'Windows'}
 
-        output = templates.create_machine_meta(template, portmaps)
-        expected = {'vm01': {'ip': '1.2.3.4', 'kind': 'myCoolTemplate', 'ports': [22]},
-                    'vm02': {'ip': '1.2.3.5', 'kind': 'myCoolTemplate', 'ports': [443]}}
+        output = templates.create_machine_meta(template, portmaps, vm_kind_map)
+        expected = {'vm01': {'ip': '1.2.3.4', 'kind': 'OneFS', 'ports': [22]},
+                    'vm02': {'ip': '1.2.3.5', 'kind': 'Windows', 'ports': [443]}}
 
         self.assertEqual(output, expected)
 


### PR DESCRIPTION
I know, one commit with two bug fixes. Bad Nick!

The first bug is that the `meta.json` stored the name of the template, instead of the kind of VM (i.e. OneFS, Windows, etc).

The other bug is that the OVAs name the networks based off the network they're connected to. This matters for OneFS because it has three NICs. The name to _what the NIC is for_ mapping doesn't carry over from the OneFS simulator (aka OVA) that Dell EMC provides for test/lab usage. This is kind nice, actually, because matching the names is simpler.